### PR TITLE
Linking custom name in creating UAA instance

### DIFF
--- a/predix/admin/uaa.py
+++ b/predix/admin/uaa.py
@@ -24,7 +24,7 @@ class UserAccountAuthentication(object):
         self.use_class = predix.security.uaa.UserAccountAuthentication
 
         self.service = predix.admin.service.CloudFoundryService(self.service_name,
-                self.plan_name)
+                self.plan_name, name=name)
         self.is_admin = False
 
         # If UAA already created we can authenticate immediately


### PR DESCRIPTION
When a call to create a UAA instance using
“UserAccountAuthentication(plan_name='Free’, name=‘custom_name’)” was
made, the instance was named the default value
’predixpy-demo-predix-uaa-free’ rather than the given name. This is a simple fix to accept custom
names.