### PR TITLE
Fix error logging in Python3

### DIFF
--- a/predix/security/uaa.py
+++ b/predix/security/uaa.py
@@ -266,7 +266,7 @@ class UserAccountAuthentication(object):
         if response.status_code == 200:
             return response.json()
         else:
-            logging.error("ERROR=" + response.content)
+            logging.error(b"ERROR=" + response.content)
             response.raise_for_status()
 
     def _post(self, uri, data, headers=None):
@@ -287,7 +287,7 @@ class UserAccountAuthentication(object):
         if response.status_code in [200, 201]:
             return response.json()
         else:
-            logging.error("ERROR=" + response.content)
+            logging.error(b"ERROR=" + response.content)
             response.raise_for_status()
 
     def get_token(self):


### PR DESCRIPTION
The `content` field in `requests` response is of type `bytes`. Python3 doesn't like to concatenate `str` and `bytes`. I propose a small change which is compatible both with Python2 and Python3.