### PR TITLE
Fix adding UAA service in the manifest

### DIFF
--- a/predix/admin/app.py
+++ b/predix/admin/app.py
@@ -78,7 +78,8 @@ class Manifest(predix.app.Manifest):
         uaa = predix.admin.uaa.UserAccountAuthentication(**kwargs)
         if not uaa.exists():
             uaa.create(admin_secret, **kwargs)
-            uaa.add_to_manifest(self)
+
+        uaa.add_to_manifest(self)
         return uaa
 
     def create_client(self, client_id=None, client_secret=None, uaa=None):


### PR DESCRIPTION
When creating the `manifest.yml` file from a `setup.py` script, if the UAA service already exists, it is not automatically added to the manifest whereas it is the case for other services.

I propose a small change to add the UAA service in the manifest even if the service is already created.