### PR TITLE
Allow passing through arbitrary aggregations

### DIFF
--- a/predix/data/timeseries.py
+++ b/predix/data/timeseries.py
@@ -312,11 +312,7 @@ class TimeSeries(object):
                 if not isinstance(aggregations, list):
                     aggregations = [aggregations]
 
-                query['aggregations'] = []
-                for aggregation in aggregations:
-                    query['aggregations'].append({
-                        'sampling': {'datapoints': 1},
-                        'type': aggregation })
+                query['aggregations'] = aggregations
 
             params['tags'].append(query)
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 install_requires = [
-        "python-dateutil==2.6.0",
+        "python-dateutil>=2.6.0",
         "boto3",
         "PyYAML",
         "requests",

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ install_requires = [
         "six",
         "future",
         "psycopg2",
-        "websocket",
         "websocket-client"
     ]
 


### PR DESCRIPTION
Currently the implementation in the library is very limited when trying to use aggregations as it can only be used to reduce the results to a single value, such as averaging/summing all datapoints.  

With this change its possible to specify more advanced aggregations supported by the Timeseries API for example a daily average `[{ type: 'avg', interval: '1d' }]`